### PR TITLE
Added option to define TAG_WIDTH as input & highlighting of errors and warnings

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -203,4 +203,6 @@ while True:
     line = linebuf.getvalue()
         
   print line
-  if len(line) == 0: break
+  if len(line) == 0:
+    input = os.popen('adb wait-for-device')
+    input = os.popen('adb logcat')


### PR DESCRIPTION
If you use
pidcat.py com.example.app 60
you have a TAG_WIDTH of 60

If you just use
pidcat.py com.example.app
you have the default TAG_WIDTH of 22

Message highlighting can be disabled / enabled by setting message_colored to True or False.
