### PR TITLE
Pidcat should not crash with 'UnicodeDecodeError'

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -169,9 +169,15 @@ def parse_death(tag, message):
 
 while adb.poll() is None:
   try:
-    line = adb.stdout.readline().decode('utf-8').strip()
+    line_raw = adb.stdout.readline()
   except KeyboardInterrupt:
     break
+
+  try:
+    line = line_raw.decode('utf-8').strip()
+  except UnicodeDecodeError:
+    line = line_raw.strip()
+
   if len(line) == 0:
     break
 


### PR DESCRIPTION
In some device, some log messages are not encoded to UTF-8.
It's a workaround for them.
