### PR TITLE
Fix bug line matching.

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -176,7 +176,7 @@ while adb.poll() is None:
     break
 
   bug_line = BUG_LINE.match(line)
-  if bug_line is None:
+  if bug_line is not None:
     continue
 
   log_line = LOG_LINE.match(line)


### PR DESCRIPTION
The commit 9ca81d87df473d0c4e94e26719f243c9db270a72 broke the bugline matching. Because only bug-lines were processed further no output is produced as no "start process" lines can be found anymore.
