### PR TITLE
Replace tabs with four spaces.

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -69,6 +69,7 @@ def colorize(message, fg=None, bg=None):
 def indent_wrap(message):
   if width == -1:
     return message
+  message = message.replace('\t', '    ')
   wrap_area = width - header_size
   messagebuf = ''
   current = 0


### PR DESCRIPTION
It appears that java stack dumps contain the tab character. This causes
line length computation to be messed up, so (on at least some
terminals), the lines end up wrapping twice -- once when we hit the
right edge of the terminal, and then again a few characters later when
indent_wrap() inserts a newline. By using spaces, where pidcat and the
terminal can agree on the width of the character, we obviate this
problem.
