### PR TITLE
Use ps command to detect PIDs

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -137,7 +137,7 @@ TAGTYPES = {
 LOG_LINE  = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*?)$')
 BUG_LINE  = re.compile(r'.*nativeGetEnabledTags.*')
 
-PS_POLLING_INTERVAL = 1
+PS_POLLING_INTERVAL_SECS = 1
 
 adb_options = []
 if args.device_serial:
@@ -212,7 +212,7 @@ def update_pids():
 def update_pids_background():
   while True:
     update_pids()
-    time.sleep(PS_POLLING_INTERVAL)
+    time.sleep(PS_POLLING_INTERVAL_SECS)
 
 lock = threading.RLock()
 thread.start_new_thread(update_pids_background, ())


### PR DESCRIPTION
As we discussed on #31, there is no log with `'Start proc...'` in Samsung Galaxy's logcat, so our parsing mechanism does not work. I ended up with using ps command to detect pids instead of parsing logcat.
However, running ps command regularly is not real time anymore. I mean, there is a slight time lag before detect pid after starting the process, which causes the problem that some logs are missing (does not show up) especially right after starting the process.

Do you think this fix is reasonable enough? If you have a better solution, please let me know.
