### PR TITLE
added option to always display tag name, so that we can pipe its output ...

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -248,4 +248,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf)
+  print(linebuf.encode('utf-8'))


### PR DESCRIPTION
Hey, 

I wanted to filter `dalvikvm` logs from `pidcat` output. So, it would be nice to have an option to always display tagname, so that we can pipe its output to `grep` and filter certain tags.

``` bash
./pidcat.py -l D  --always-display-tags com.trhura.android.somepackage | grep -v -e "dalvikvm"
```
