### PR TITLE
Allow package to specify a process as well …

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -44,6 +44,13 @@ parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true'
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level]
 
+# Store the names of packages for which to match all processes.
+catchall_package = filter(lambda package: package.find(":") == -1, args.package)
+# Store the name of processes to match exactly.
+named_processes = filter(lambda package: package.find(":") != -1, args.package)
+# Convert default process names from <package>: (cli notation) to <package> (android notation) in the exact names match group.
+named_processes = map(lambda package: package if package.find(":") != len(package) - 1 else package[:-1], named_processes)
+
 header_size = args.tag_width + 1 + 3 + 1 # space, level, space
 
 width = -1
@@ -157,8 +164,10 @@ app_pid = None
 def match_packages(token):
   if len(args.package) == 0:
     return True
+  if token in named_processes:
+    return True
   index = token.find(':')
-  return (token in args.package) if index == -1 else (token[:index] in args.package)
+  return (token in catchall_package) if index == -1 else (token[:index] in catchall_package)
 
 def parse_death(tag, message):
   if tag != 'ActivityManager':


### PR DESCRIPTION
Add a process name filtering method in addition to package filtering. This means the package argument would now be more of a process name with some specific rules, which is easier to manage than adding a -p argument (annoying to match with multiple arguments).

With this change, `pidcat com.android.chrome` will match all of chrome's processes, `pidcat com.android.chrome:` will only match its main process and `pidcat com.android.chrome:sandboxed_process1` will match the first sandbox process.

Note that existing users aren't affected since normal package names are still treated as matching all processes as before.
