### PR TITLE
Fixed path to adb in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,9 @@ enter into your terminal something actually happens.
 To include `adb` and other android tools on your path:
 
     export PATH=$PATH:<path to Android SDK>/platform-tools
-
-and
-
     export PATH=$PATH:<path to Android SDK>/tools
 
-Include that line in your `.bashrc` or `.zshrc`.
+Include these lines in your `.bashrc` or `.zshrc`.
 
 
 


### PR DESCRIPTION
Dear Jake,

on my Android SDK installation the adb had been moved to /sdk/platform-tools and i was guided to include both folders (platform-tools and tools) into my PATH.

I fixed your Readme accordingly to guide other guys going this way.

Regards,
Danny Fürniß
