### PR TITLE
optionally add the events buffer as a workaround for Samsung devices

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -41,6 +41,7 @@ parser.add_argument('-s', '--serial', dest='device_serial', help='Device serial 
 parser.add_argument('-d', '--device', dest='use_device', action='store_true', help='Use first device for log input (adb -d option).')
 parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true', help='Use first emulator for log input (adb -e option).')
 parser.add_argument('-c', '--clear', dest='clear_logcat', action='store_true', help='Clear the entire log before running.')
+parser.add_argument('-b', '--events-log', dest='add_events_log', action='store_true', help='Include the events log buffer. Useful for Samsung devices.')
 
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level]
@@ -140,7 +141,8 @@ TAGTYPES = {
   'F': colorize(' F ', fg=BLACK, bg=RED),
 }
 
-PID_START = re.compile(r'^Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
+PID_START_MAIN = re.compile(r'^Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
+PID_START_EVENTS = re.compile(r'^\[.*?(\d+),(\d+),([a-zA-Z0-9._:]+),[^,]+,([a-z]+[^],]+)\]$')
 PID_KILL  = re.compile(r'^Killing (\d+):([a-zA-Z0-9._:]+)/[^:]+: (.*)$')
 PID_LEAVE = re.compile(r'^No longer want ([a-zA-Z0-9._:]+) \(pid (\d+)\): .*$')
 PID_DEATH = re.compile(r'^Process ([a-zA-Z0-9._:]+) \(pid (\d+)\) has died.?$')
@@ -156,6 +158,9 @@ if args.use_device:
 if args.use_emulator:
   adb_command.append('-e')
 adb_command.append('logcat')
+if args.add_events_log:
+  # default seems to be main + system buffers
+  adb_command.extend(['-b', 'main', '-b', 'system', '-b', 'events'])
 
 # Clear log before starting logcat
 if args.clear_logcat:
@@ -220,11 +225,17 @@ while adb.poll() is None:
 
   level, tag, owner, message = log_line.groups()
 
-  start = PID_START.match(message)
-  if start is not None:
-    line_package, target, line_pid, line_uid, line_gids = start.groups()
+  start_main = PID_START_MAIN.match(message)
+  if start_main is not None:
+    line_package, target, line_pid, line_uid, line_gids = start_main.groups()
 
-    if match_packages(line_package):
+  start_events = PID_START_EVENTS.match(message) if tag == 'am_proc_start' else None
+  if start_events is not None:
+    line_pid, line_uid, line_package, target = start_events.groups()
+    line_gids = '(not available)'
+
+  if start_main or start_events:
+    if match_packages(line_package) and line_pid not in pids:
       pids.add(line_pid)
 
       app_pid = line_pid


### PR DESCRIPTION
workaround for issue #31

The idea is to look in the events buffer, where 'am_proc_start' lines can be found containing the PID.

The message regex is a bit tricky because the format seems to depend on the OS version. 
Some examples :

```
# WIKO-CINK-SLIM 4.0.4
[18384,10083,com.rayonnance.idtekt,activity,com.rayonnance.idtekt/.MainActivity]
# some Galaxy tablet (GT-N8000) 4.1.2
[9773,10016,com.google.android.gms,service,com.google.android.gms/.icing.service.IndexService]

#4.4.2 : there is an additional number

#Galaxy S, cynanogenmod 11, 4.4.2
[0,2011,10017,com.google.android.configupdater,broadcast,com.google.android.configupdater/.CertPin.CertPinUpdateRequestReceiver]
# Nexus 5, 4.4.2
[0,21185,10054,com.google.android.inputmethod.latin,broadcast,com.google.android.inputmethod.latin/com.android.inputmethod.dictionarypack.EventHandler]
# Galaxy Note 3 (SM-N9005), 4.4.2
[0,23752,10150,com.android.providers.calendar,content provider,com.android.providers.calendar/.CalendarProvider2]
```
