### PR TITLE
Print line if we have not seen any pids created yet

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -253,7 +253,7 @@ while adb.poll() is None:
       message = message.lstrip()
       owner = app_pid
 
-  if owner not in pids:
+  if not pids and owner not in pids:
     continue
   if level in LOG_LEVELS_MAP and LOG_LEVELS_MAP[level] < min_level:
     continue


### PR DESCRIPTION
This specifically handles the case where you get a log snippet that may
not have any pid creation lines in it and pidcat ends up filtering
everything out. In this case we just print the line if we haven't seen
any pids yet.

An alternative would be allowing filter by pid, however I find grep
works fine for that.
