### PR TITLE
Print line if we have not seen any pids created yet

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -176,6 +176,7 @@ if sys.stdin.isatty():
 else:
   adb = FakeStdinProcess()
 pids = set()
+seen_pids = False
 last_tag = None
 app_pid = None
 
@@ -234,6 +235,7 @@ while adb.poll() is None:
 
     if match_packages(line_package):
       pids.add(line_pid)
+      seen_pids = True
 
       app_pid = line_pid
 
@@ -263,7 +265,7 @@ while adb.poll() is None:
       message = message.lstrip()
       owner = app_pid
 
-  if owner not in pids:
+  if seen_pids and owner not in pids:
     continue
   if level in LOG_LEVELS_MAP and LOG_LEVELS_MAP[level] < min_level:
     continue


### PR DESCRIPTION
This specifically handles the case where you get a log snippet that may
not have any pid creation lines in it and pidcat ends up filtering
everything out. In this case we just print the line if we haven't seen
any pids yet.

An alternative would be allowing filter by pid, however I find grep
works fine for that.
