### PR TITLE
Handle alternative start proc log line

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -139,7 +139,8 @@ TAGTYPES = {
   'F': colorize(' F ', fg=BLACK, bg=RED),
 }
 
-PID_START = re.compile(r'^Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
+PID_START = re.compile(r'^.*: Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
+PID_START_DALVIK = re.compile(r'^E/dalvikvm\((\d+)\): >>>>> ([a-zA-Z0-9._:]+) \[ userId:0 \| appId:(\d+) \]$')
 PID_KILL  = re.compile(r'^Killing (\d+):([a-zA-Z0-9._:]+)/[^:]+: (.*)$')
 PID_LEAVE = re.compile(r'^No longer want ([a-zA-Z0-9._:]+) \(pid (\d+)\): .*$')
 PID_DEATH = re.compile(r'^Process ([a-zA-Z0-9._:]+) \(pid (\d+)\) has died.?$')
@@ -211,6 +212,17 @@ def parse_death(tag, message):
       return pid, package_line
   return None, None
 
+def parse_start_proc(line):
+  start = PID_START.match(line)
+  if start is not None:
+    line_package, target, line_pid, line_uid, line_gids = start.groups()
+    return line_package, target, line_pid, line_uid, line_gids
+  start = PID_START_DALVIK.match(line)
+  if start is not None:
+    line_pid, line_package, line_uid = start.groups()
+    return line_package, '', line_pid, line_uid, ''
+  return None
+
 while adb.poll() is None:
   try:
     line = adb.stdout.readline().decode('utf-8', 'replace').strip()
@@ -228,11 +240,9 @@ while adb.poll() is None:
     continue
 
   level, tag, owner, message = log_line.groups()
-
-  start = PID_START.match(message)
-  if start is not None:
-    line_package, target, line_pid, line_uid, line_gids = start.groups()
-
+  start = parse_start_proc(line)
+  if start:
+    line_package, target, line_pid, line_uid, line_gids = start
     if match_packages(line_package):
       pids.add(line_pid)
 


### PR DESCRIPTION
Add support for an alternative log format for starting new processes.  Also reverts the "print line if we have not seen any pids" diff, which it sounds like was motivated by this flaw?  Either way that change is fairly harmful to what I believe is normal use of pidcat.  
