### PR TITLE
Fix failure to match new format start messages

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -140,7 +140,7 @@ TAGTYPES = {
 }
 
 PID_START = re.compile(r'^.*: Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
-PID_START_DALVIK = re.compile(r'^E/dalvikvm\((\d+)\): >>>>> ([a-zA-Z0-9._:]+) \[ userId:0 \| appId:(\d+) \]$')
+PID_START_DALVIK = re.compile(r'^E/dalvikvm\(\s?(\d+)\): >>>>> ([a-zA-Z0-9._:]+) \[ userId:0 \| appId:(\d+) \]$')
 PID_KILL  = re.compile(r'^Killing (\d+):([a-zA-Z0-9._:]+)/[^:]+: (.*)$')
 PID_LEAVE = re.compile(r'^No longer want ([a-zA-Z0-9._:]+) \(pid (\d+)\): .*$')
 PID_DEATH = re.compile(r'^Process ([a-zA-Z0-9._:]+) \(pid (\d+)\) has died.?$')


### PR DESCRIPTION
For low pids there's a space in front of the PID in the log message.
All my testing was on high pids :(
