### PR TITLE
Added clear screen, verbose mode and time stamps. Added usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ During application development you often want to only display log messages
 coming from your app. Unfortunately, because the process ID changes every time
 you deploy to the phone it becomes a challenge to grep for the right thing.
 
-This script solves that problem by filtering by application package. Supply the
-target package as the sole argument to the python script and enjoy a more
+This script solves that problem by filtering the logs by application package name.
+Supply the target package as the sole argument to the python script and enjoy a more
 convenient development process.
 
     pidcat com.oprah.bees.android
@@ -42,6 +42,15 @@ To include `adb` and other android tools on your path:
     export PATH=$PATH:<path to Android SDK>/tools
 
 Include these lines in your `.bashrc` or `.zshrc`.
+
+Usage
+-----
+    pidcat.py [-h] [-w N] [-l {V,D,I,W,E,F,v,d,i,w,e,f}] [--color-gc]
+              [--always-display-tags] [-s DEVICE_SERIAL] [-d] [-e] [-c]
+              [-t TAG] [-i IGNORED_TAG] [--verbose]
+              [package [package ...]]
+
+You can pass more than one package name at a time.
 
 
 


### PR DESCRIPTION
I wasn't planning on forking and pushing, so I have 3 features in this commit. I hope that this is ok..

I had trouble getting pidcat to work the first time I tried it. In reality, it was working as expected but it wasn't printing anything.  So I added some log lines that are only visible when --verbose is specified as an argument.

Two issues that I had once pidcat started outputting my logs were that I couldn't clear the output, and I wasn't sure if I was seeing output from this 'run' or a previous 'run'.  So I added a time stamp to the beginning and ending of the application 'run'. And last but not least I added a Thread that waits for keystrokes and that will clear the screen if the user clicks C or Space. This required changing the TTY to rawmode and for me to add '\r' to the prints.

I will have another pull request for you, probably tonight.  It's mostly just cleanup in the file. putting the consts at the top, then classes, defs, and the main code. Also added some space between the code. Up to you if you like it or not :)

Added the use to the README file

-MIke