### PR TITLE
Add --version, remove trailing spaces in help texts

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -27,6 +27,8 @@ import re
 import subprocess
 from subprocess import PIPE
 
+__version__ = '1.4.1'
+
 LOG_LEVELS = 'VDIWEF'
 LOG_LEVELS_MAP = dict([(LOG_LEVELS[i], i) for i in range(len(LOG_LEVELS))])
 parser = argparse.ArgumentParser(description='Filter logcat by package name')
@@ -36,11 +38,12 @@ parser.add_argument('-l', '--min-level', dest='min_level', type=str, choices=LOG
 parser.add_argument('--color-gc', dest='color_gc', action='store_true', help='Color garbage collection')
 parser.add_argument('--always-display-tags', dest='always_tags', action='store_true',help='Always display the tag name')
 parser.add_argument('-s', '--serial', dest='device_serial', help='Device serial number (adb -s option)')
-parser.add_argument('-d', '--device', dest='use_device', action='store_true', help='Use first device for log input (adb -d option).')
-parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true', help='Use first emulator for log input (adb -e option).')
-parser.add_argument('-c', '--clear', dest='clear_logcat', action='store_true', help='Clear the entire log before running.')
+parser.add_argument('-d', '--device', dest='use_device', action='store_true', help='Use first device for log input (adb -d option)')
+parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true', help='Use first emulator for log input (adb -e option)')
+parser.add_argument('-c', '--clear', dest='clear_logcat', action='store_true', help='Clear the entire log before running')
 parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter output by specified tag(s)')
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
+parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Print the version number and exit')
 
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level.upper()]


### PR DESCRIPTION
Fixes #83.

Sample output:
```Shell
$ pidcat.py --version
pidcat.py 1.4.1
```
Taken from [this SO post](http://stackoverflow.com/a/459185/1928168) and [PEP-440](https://www.python.org/dev/peps/pep-0440). 

I'd love to include the info `git describe --tags` provides, but PEP-440 has the following to say about [DVCS based version labels](https://www.python.org/dev/peps/pep-0440/#dvcs-based-version-labels):
> Many build tools integrate with distributed version control systems like Git and Mercurial in order to add an identifying hash to the version identifier. **As hashes cannot be ordered reliably such versions are not permitted in the public version field.**

But we could use the allowed `.devN` suffix where N could be the number of additional commits on top of the tagged release. Or all of this would be overkill for such a small script.

I also removed the trailing `.`s for some help texts to stay consistent, sorry for not making these atomic commits, I could split them if you want.