### PR TITLE
disabled some opengl error to be shown

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -152,6 +152,8 @@ PID_LEAVE = re.compile(r'^No longer want ([a-zA-Z0-9._:]+) \(pid (\d+)\): .*$')
 PID_DEATH = re.compile(r'^Process ([a-zA-Z0-9._:]+) \(pid (\d+)\) has died.?$')
 LOG_LINE  = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*?)$')
 BUG_LINE  = re.compile(r'.*nativeGetEnabledTags.*')
+BUG_LINE2  = re.compile(r'.*glUtilsParamSize.*')
+BUG_LINE3  = re.compile(r'.*glSizeof.*')
 BACKTRACE_LINE = re.compile(r'^#(.*?)pc\s(.*?)$')
 
 base_adb_command = ['adb']
@@ -265,6 +267,12 @@ while adb.poll() is None:
 
   bug_line = BUG_LINE.match(line)
   if bug_line is not None:
+    continue
+  bug_line2 = BUG_LINE2.match(line)
+  if bug_line2 is not None:
+    continue
+  bug_line3 = BUG_LINE3.match(line)
+  if bug_line3 is not None:
     continue
 
   log_line = LOG_LINE.match(line)


### PR DESCRIPTION
If you're developing with an emulator with hardware acceleration some OpenGL bug can be annoying. This is an easy fix and there are still some TODOs:

1. Should be emulator only
2. Those BUG_LINEs should be put in an array or what so ever makes sense in python, or
3. Add a new command-line option to control such behavior

But overall it solves my problem for now :)