### PR TITLE
Fix "--curent" bugs

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -51,9 +51,18 @@ min_level = LOG_LEVELS_MAP[args.min_level.upper()]
 
 package = args.package
 
+base_adb_command = ['adb']
+if args.device_serial:
+  base_adb_command.extend(['-s', args.device_serial])
+if args.use_device:
+  base_adb_command.append('-d')
+if args.use_emulator:
+  base_adb_command.append('-e')
+
 if args.current_app:
-  system_dump = subprocess.Popen('adb shell dumpsys activity activities', shell=True, stdout=PIPE, stderr=PIPE).communicate()[0]
-  running_package_name = re.search(".*Recent.*A=([^ ]*)", system_dump).group(1)
+  system_dump_command = base_adb_command + ["shell", "dumpsys", "activity", "activities"]
+  system_dump = subprocess.Popen(system_dump_command, stdout=PIPE, stderr=PIPE).communicate()[0]
+  running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump).group(1)
   package.append(running_package_name)
 
 # Store the names of packages for which to match all processes.
@@ -162,13 +171,6 @@ LOG_LINE  = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*?)$')
 BUG_LINE  = re.compile(r'.*nativeGetEnabledTags.*')
 BACKTRACE_LINE = re.compile(r'^#(.*?)pc\s(.*?)$')
 
-base_adb_command = ['adb']
-if args.device_serial:
-  base_adb_command.extend(['-s', args.device_serial])
-if args.use_device:
-  base_adb_command.append('-d')
-if args.use_emulator:
-  base_adb_command.append('-e')
 adb_command = base_adb_command[:]
 adb_command.append('logcat')
 


### PR DESCRIPTION
Sorry for my bad English.

This pull request will fix the following problems.
 * --current ignore adb option that like `-s` `-d` `-e`. 
 * --current Lollipop crash.
 * --current 2.x crash.

`dumpsys activity activities` command of Lollipop devices doesn't show recent tasks. So, It cause crash.

```
Traceback (most recent call last):
  File "pidcat.py", line 56, in <module>
    running_package_name = re.search(".*Recent.*A=([^ ]*)", system_dump).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

I fixed crash by changing `.*Recent.*A=([^ ]*)` to `.*TaskRecord.*A[= ]([^ ^}]*)`.
It use activity stack data. And  changing `=` to `[= ]` and `[^ ]` to `[^ ^}]`.
Because, `dumpsys activity activities` command displays the following results.
Android 2.x

```
  * TaskRecord{b65f4218 #2 A com.android.launcher}
```

Android 4.x-
```
      TaskRecord{5298a0f8 #1 A=com.android.launcher U=0 sz=1}
```