### PR TITLE
explicitly run adb logcat command in brief format

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -171,6 +171,7 @@ if args.use_emulator:
   base_adb_command.append('-e')
 adb_command = base_adb_command[:]
 adb_command.append('logcat')
+adb_command.extend(['-v', 'brief'])
 
 # Clear log before starting logcat
 if args.clear_logcat:


### PR DESCRIPTION
On my Nexus 6 with Android M Preview, the logcat output by default is in this `threadtime` format:

```
06-06 11:10:37.490  2830  3273 D WifiHAL : Stopping GScan
06-06 11:10:37.490  2830  3273 D WifiHAL : Stopping scan
06-06 11:10:37.492  2830  3273 D wifi    : Initialized common fields 60000, 25, 100, 10
06-06 11:10:37.492  2830  3273 D wifi    : bucket[0] = 4:3:60000:0
06-06 11:10:37.492  2830  3273 D WifiHAL : Starting GScan, halHandle = 0xaf11a640
06-06 11:10:37.492  2830  3273 D WifiHAL : GSCAN start
06-06 11:10:37.492  2830  3273 I WifiHAL : bucket 0: period 60000 band 3 report 0
06-06 11:10:37.492  2830  3273 D WifiHAL :  ....starting scan
```

As a result pidcat is unable to parse properly.

This patch forces pidcat to run the logcat command with the `brief` format and allows proper parsing.