### PR TITLE
add -n/--no-color option to output log without color

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -27,7 +27,7 @@ import re
 import subprocess
 from subprocess import PIPE
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 LOG_LEVELS = 'VDIWEF'
 LOG_LEVELS_MAP = dict([(LOG_LEVELS[i], i) for i in range(len(LOG_LEVELS))])
@@ -46,6 +46,7 @@ parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter out
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
 parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Print the version number and exit')
 parser.add_argument('-a', '--all', dest='all', action='store_true', default=False, help='Print all log messages')
+parser.add_argument('-n', '--no-color', dest='no_color', action='store_true', default=False, help='Do not use colorful output')
 
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level.upper()]
@@ -97,7 +98,10 @@ def termcolor(fg=None, bg=None):
   return '\033[%sm' % ';'.join(codes) if codes else ''
 
 def colorize(message, fg=None, bg=None):
-  return termcolor(fg, bg) + message + RESET
+   if args.no_color:
+     return message
+   else:
+     return termcolor(fg, bg) + message + RESET
 
 def indent_wrap(message):
   if width == -1:

--- a/zsh-completion/_pidcat
+++ b/zsh-completion/_pidcat
@@ -57,6 +57,7 @@ _pidcat() {
     '-v[Print the version number and exit]' \
     '-l[Minimum level to be displayed]: :_pidcat_log_levels' \
     '-a[Print all log messages]' \
+    '-n[Do not  user colorful output]' \
     '--color-gc[Color garbage collection]' \
     '--always-display-tags[Always display the tag name]' \
     '--current[Filter logcat by current running app]' \


### PR DESCRIPTION
- useful for getting a clean log file when we redirect output to a log
  file


add -n option to allow pidcat output log with color. It's especially useful when we try to redirect output to a log file. Without color meta data, we can get a clean log file.