### PR TITLE
Fix bug: may fail to get target pid

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -254,7 +254,7 @@ def tag_in_tags_regex(tag, tags):
 
 ps_command = base_adb_command + ['shell', 'ps']
 ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-while ps_pid.poll() is None:
+while True:
   try:
     line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
   except KeyboardInterrupt:


### PR DESCRIPTION
    if use ps_pid.poll() to check for termination condition, there is a
    race condition. consider this, the check for ps_pid.poll() succeed
    and continue to process the output. when the output is being
    processed, the "ps_pid" process terminated, generating some more
    output, which hasn't yet been read by pidcat process. after pidcat
    continues next loop iteration, the ps_pid.poll() check terminate the
    loop, and the remaining output is lost. if the target process's pid
    is in the lost output, then the target pid can't be retrieved.