### PR TITLE
Add --time option to show log time

### DIFF
--- a/zsh-completion/_pidcat
+++ b/zsh-completion/_pidcat
@@ -58,6 +58,7 @@ _pidcat() {
     '-l[Minimum level to be displayed]: :_pidcat_log_levels' \
     '-a[Print all log messages]' \
     '--color-gc[Color garbage collection]' \
+    '--time[Print time]' \
     '--always-display-tags[Always display the tag name]' \
     '--current[Filter logcat by current running app]' \
     '*:: :_pidcat_processes' \


### PR DESCRIPTION
- change default format from brief to time
- add --time option, default to False
- when --time is set, the log time will be printed