### PR TITLE
Handle case when passing --current with no running application

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -63,8 +63,11 @@ if args.use_emulator:
 if args.current_app:
   system_dump_command = base_adb_command + ["shell", "dumpsys", "activity", "activities"]
   system_dump = subprocess.Popen(system_dump_command, stdout=PIPE, stderr=PIPE).communicate()[0]
-  running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump).group(1)
-  package.append(running_package_name)
+  try:
+    running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump).group(1)
+    package.append(running_package_name)
+  except:
+    pass
 
 if len(package) == 0:
   args.all = True


### PR DESCRIPTION
When passing --current without any running application on the device, we get an `AttributeError`.
Ignore it and display the whole log.

```
➜  pidcat git:(master) ✗ pidcat --current
Traceback (most recent call last):
  File "/usr/local/bin/pidcat", line 66, in <module>
    running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```
