### PR TITLE
Add pass-through of adb errors

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -196,7 +196,7 @@ class FakeStdinProcess():
     return None
 
 if sys.stdin.isatty():
-  adb = subprocess.Popen(adb_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+  adb = subprocess.Popen(adb_command, stdin=PIPE, stdout=PIPE)
 else:
   adb = FakeStdinProcess()
 pids = set()


### PR DESCRIPTION
This pull requests causes adb to inherit stderr from pidcat. This is useful when, for example, no `-d`, `-e`, or `-s` flag is present and adb would emit a "more than one device" error, but the error would be gobbled up by pidcat and nothing is output to the terminal.

Previously when multiple devices are present:
```
$ pidcat
$
```
By inheriting stderr:
```
$ pidcat
- waiting for device -
error: more than one device/emulator
$
```

In my testing, logcat doesn't appear to output to stderr normally so this change should not affect pidcat's normal behavior.