### PR TITLE
Fix blank line cause silent quit.

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -272,11 +272,15 @@ while True:
 
 while adb.poll() is None:
   try:
-    line = adb.stdout.readline().decode('utf-8', 'replace').strip()
+    line = adb.stdout.readline()
   except KeyboardInterrupt:
     break
   if len(line) == 0:
     break
+
+  line = line.decode('utf-8', 'replace').strip()
+  if len(line) == 0:
+    continue
 
   bug_line = BUG_LINE.match(line)
   if bug_line is not None:


### PR DESCRIPTION
when logcat output blank line, pidcat will silent quit.