### PR TITLE
Make shebang more portable

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env -S python -u
 
 '''
 Copyright 2009, The Android Open Source Project


### PR DESCRIPTION
Distros like NixOS[1] do not have a typical /usr/bin/, and rely on shebangs
using /usr/bin/env to go to the correct binary.

Passing options to interpreters is not directly supported in env, and thus
requires passing an extra -S[2] to ensure they go through correctly.

1: https://nixos.org
2: https://jhermann.github.io/blog/linux/know-how/2020/02/28/env_with_arguments.html
