### PR TITLE
pidcat: print a newline when SIGINT is sent

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -22,6 +22,7 @@ limitations under the License.
 # Package filtering and output improvements by Jake Wharton, http://jakewharton.com
 
 import argparse
+import signal
 import sys
 import re
 import subprocess
@@ -46,6 +47,12 @@ parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter out
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
 parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Print the version number and exit')
 parser.add_argument('-a', '--all', dest='all', action='store_true', default=False, help='Print all log messages')
+
+def signal_handler(sig, frame):
+  print('')
+  sys.exit(signal.SIGINT)
+
+signal.signal(signal.SIGINT, signal_handler)
 
 args = parser.parse_args()
 min_level = LOG_LEVELS_MAP[args.min_level.upper()]


### PR DESCRIPTION
Ctrl + C/Cmd + C is, what I believe, a pretty common way of exiting from pidcat, but the default behavior results in prompts getting messed up because there is no final newline. ZSH seems to work around it by indicating that there's a missing newline in the output and adding one itself, but most other shell/prompt combinations do not have that feature, so we need this as a workaround.

I haven't written any worthwhile Python in a while so I'm open to any suggestions on doing this in a better way, but this works for me on Python 2.7. Python 3's Unicode changes currently break the terminal colors output, I'll submit a PR as soon as I have some time to make the necessary changes (hopefully in a day or two).
