### PR TITLE
Migrate to Python 3

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python -u
+#!/usr/bin/env -S python3 -u
 
 '''
 Copyright 2009, The Android Open Source Project

--- a/pidcat.py
+++ b/pidcat.py
@@ -70,11 +70,11 @@ if len(package) == 0:
   args.all = True
 
 # Store the names of packages for which to match all processes.
-catchall_package = filter(lambda package: package.find(":") == -1, package)
+catchall_package = [package for package in package if package.find(":") == -1]
 # Store the name of processes to match exactly.
-named_processes = filter(lambda package: package.find(":") != -1, package)
+named_processes = [package for package in package if package.find(":") != -1]
 # Convert default process names from <package>: (cli notation) to <package> (android notation) in the exact names match group.
-named_processes = map(lambda package: package if package.find(":") != len(package) - 1 else package[:-1], named_processes)
+named_processes = [package if package.find(":") != len(package) - 1 else package[:-1] for package in named_processes]
 
 header_size = args.tag_width + 1 + 3 + 1 # space, level, space
 
@@ -86,7 +86,7 @@ try:
 except:
   pass
 
-BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
+BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = list(range(8))
 
 RESET = '\033[0m'
 
@@ -357,4 +357,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf.encode('utf-8'))
+  print(linebuf)


### PR DESCRIPTION
Turned out to not be that much of a problem. I've also included suggestions from
the `2to3` migration tool Python shipped, and updated the shebang to be py3.
