### PR TITLE
Add alternate buffer argument, fixes (#128)

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -41,6 +41,7 @@ parser.add_argument('--current', dest='current_app', action='store_true',help='F
 parser.add_argument('-s', '--serial', dest='device_serial', help='Device serial number (adb -s option)')
 parser.add_argument('-d', '--device', dest='use_device', action='store_true', help='Use first device for log input (adb -d option)')
 parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true', help='Use first emulator for log input (adb -e option)')
+parser.add_argument('-b', '--buffer', dest='alternate_buffer', nargs='+', help='Request alternate ring buffer')
 parser.add_argument('-c', '--clear', dest='clear_logcat', action='store_true', help='Clear the entire log before running')
 parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter output by specified tag(s)')
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
@@ -178,6 +179,10 @@ BACKTRACE_LINE = re.compile(r'^#(.*?)pc\s(.*?)$')
 adb_command = base_adb_command[:]
 adb_command.append('logcat')
 adb_command.extend(['-v', 'brief'])
+
+if args.alternate_buffer:
+ for buffer in args.alternate_buffer:
+   adb_command.extend(['-b', buffer])
 
 # Clear log before starting logcat
 if args.clear_logcat:


### PR DESCRIPTION
Add logcat's `-b` option for alternate buffers (#128)

Usage:
```
~/pidcat/pidcat.py -b main
```

```
~/pidcat/pidcat.py -b kernel main
```