### PR TITLE
Update to binary to python3

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python -u
+#!/usr/bin/env -S python3 -u
 
 '''
 Copyright 2009, The Android Open Source Project


### PR DESCRIPTION
Both OSX and various Linux distributions are deprecating the use of python 2 and to mark that they are forcing the python binary to be called "python3". This should prepare pidcat for this future. Python3 should already be available everywhere. This also unblocks AUR from needing a patch to the their package.