### PR TITLE
Fixes #165

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -60,12 +60,19 @@ if args.use_device:
 if args.use_emulator:
   base_adb_command.append('-e')
 
+android_version_command = base_adb_command + ["shell", "getprop", "ro.build.version.sdk"]
+android_sdk = subprocess.Popen(android_version_command, stdout=PIPE, stderr=PIPE).communicate()[0]
+
 if args.current_app:
   system_dump_command = base_adb_command + ["shell", "dumpsys", "activity", "activities"]
   system_dump = subprocess.Popen(system_dump_command, stdout=PIPE, stderr=PIPE).communicate()[0]
-  running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump).group(1)
+  if int(android_sdk) >= 30:
+    running_package_name = re.search(".*Task.*A[= ][0-9]+:([^ ^}]*)", str(system_dump)).group(1)
+  else:
+    running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", str(system_dump)).group(1)
   package.append(running_package_name)
 
+  
 if len(package) == 0:
   args.all = True
 


### PR DESCRIPTION
Changes in Android Q stopped publishing TaskRecord. 
This changes checks the sdk version of the target devices and uses the correct regex to fetch the package name of the current running app. 

Output of adb -s shell dumpsys activity activities
Api 27: 
```
ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
Display #0 (activities from top to bottom):
....
    * TaskRecord{389a1bc #66 I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity U=0 StackId=0 sz=1
    ....
      * Hist #0: ActivityRecord{67f6bb3 u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity t66}
....
```
Api 30
```
ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
Display #0 (activities from top to bottom):
  Stack #1: type=home mode=fullscreen
  ....
    * Task{3b537df #4644 visible=false type=home mode=fullscreen translucent=true I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity U=0 StackId=1 sz=1}
   ....
      * Hist #0: ActivityRecord{66c039 u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity t4644}
```

Tested on API 27, 28, 29, 30