### PR TITLE
Fix encoding issues in Python 3

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -359,4 +359,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf.encode('utf-8'))
+  print(linebuf)


### PR DESCRIPTION
Python 2 is already deprectaded, and colors don't work properly if reencoding to UTF-8.

See [Issue 18](https://github.com/JakeWharton/pidcat/issues/18#issuecomment-330394420)

With this change colors work again!