### PR TITLE
Fixed issue JakeWharton#182

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -359,4 +359,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf.encode('utf-8'))
+  print(linebuf)


### PR DESCRIPTION
Fixed issue https://github.com/JakeWharton/pidcat/issues/182 which caused colour codes to be printed instead of text being coloured when run in Python 3.